### PR TITLE
Handle the 'h' identifier for html

### DIFF
--- a/src/lib/stardict.cpp
+++ b/src/lib/stardict.cpp
@@ -275,6 +275,7 @@ QString StarDict::parseData(const char *data, int dictIndex, bool htmlSpaces, bo
             case 'm':
             case 'l':
             case 'g':
+            case 'h':
             {
                 QString str = QString::fromUtf8(ptr);
                 ptr += str.toUtf8().length() + 1;


### PR DESCRIPTION
An 'h' character indicates that what follows is html. Append it to the
result without modification. (Previously, 'h' was not handled, meaning
that it would start discarding characters from the html until it reached
one it recognised, often resulting in a broken first html tag.)

cf. https://github.com/d0b3rm4n/harbour-sidudict/blob/41c86631d23fdb291eb8672ac707573b3bd1f10a/src/lib/StarDictFileFormat#L424